### PR TITLE
fixed video encoding thing

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -75,16 +75,26 @@ function CreatePage() {
 		chunksRef.current = [];
 		setRecordedChunks([]);
 
-		// Try different mime types for better compatibility
-		let mimeType = "video/webm;codecs=vp9";
-		if (!MediaRecorder.isTypeSupported(mimeType)) {
-			mimeType = "video/webm;codecs=vp8";
-			if (!MediaRecorder.isTypeSupported(mimeType)) {
-				mimeType = "video/webm";
-				if (!MediaRecorder.isTypeSupported(mimeType)) {
-					mimeType = "video/mp4";
+		// Detect best mimeType for browser compatibility
+		function getSupportedMimeType() {
+			const possibleTypes = [
+				"video/webm;codecs=vp9,opus",
+				"video/webm;codecs=vp8,opus",
+				"video/webm",
+				"video/mp4",
+			];
+			for (const type of possibleTypes) {
+				if (MediaRecorder.isTypeSupported(type)) {
+					return type;
 				}
 			}
+			return ""; // No supported type
+		}
+
+		const mimeType = getSupportedMimeType();
+		if (!mimeType) {
+			alert("Your browser does not support video recording. Please use Chrome or a browser with MediaRecorder support.");
+			return;
 		}
 
 		const recorder = new MediaRecorder(streamRef.current, {
@@ -108,7 +118,6 @@ function CreatePage() {
 			}
 			
 			const blob = new Blob(chunksRef.current, { type: mimeType });
-			console.log("Created blob:", blob.size, "bytes, type:", blob.type);
 			const url = URL.createObjectURL(blob);
 			console.log("Created URL:", url);
 			


### PR DESCRIPTION
This pull request refactors the `CreatePage` function in `src/app/create/page.tsx` to improve browser compatibility for video recording and streamline the code. The most significant changes include introducing a helper function for detecting supported MIME types and enhancing user feedback when no supported MIME type is available.

### Improvements to MIME type detection:

* Introduced a `getSupportedMimeType` helper function to determine the best MIME type for video recording based on browser compatibility. This replaces the previous nested `if` logic with a cleaner and more maintainable approach.
* Added an alert to notify users when their browser does not support any of the tested MIME types, improving user experience.

### Code cleanup:

* Removed a redundant `console.log` statement that logged the size and type of the created blob, simplifying the logging output.